### PR TITLE
separated last comment from comment list

### DIFF
--- a/react-app/src/components/Feed/CommentView/CommentView.css
+++ b/react-app/src/components/Feed/CommentView/CommentView.css
@@ -12,4 +12,32 @@
   border-bottom-right-radius: 15px;
   padding: 10px;
   font-size: smaller;
+  /* max-width: fit-content; */
+  max-width: 385px;
+}
+.comment-text{
+  margin-top: 5px;
+}
+.edit-comment-div{
+  /* display: flex; */
+}
+.edit-comment-ellipsis{
+  color: #65676B;
+  margin-left: 5px;
+  padding: 10px;
+  cursor: pointer;
+}
+.edit-comment-ellipsis:hover{
+  background-color: rgba(211, 211, 211, 0.389);
+
+  border-radius: 100%;
+
+}
+.view-comment-text{
+  color: #65676B;
+  cursor: pointer;
+}
+.collapse-comments{
+  color: #65676B;
+  cursor: pointer;
 }

--- a/react-app/src/components/Feed/CommentView/index.js
+++ b/react-app/src/components/Feed/CommentView/index.js
@@ -3,29 +3,44 @@ import { useState } from 'react'
 import { useEffect } from 'react'
 import { useSelector, useDispatch } from "react-redux";
 import { getComments } from '../../../store/comment';
+import LastComment from '../LastComment';
+import SingleComment from '../SingleComment';
 import "./CommentView.css"
 const CommentView = ({ post }) => {
+  const current_user = useSelector(state => state.session.user)
   const comments = useSelector(state => Object.values(state.comments))
-  console.log(comments)
   const postsComments = comments.filter(comment => comment.post === post.id)
-  console.log(postsComments[postsComments.length - 1]?.comment_content)
+
+  const [showAllComments, setShowAllComments] = useState(false);
+  const lastComment = postsComments[postsComments.length - 1]
   const dispatch = useDispatch()
 
   return (
     <div>
-      {postsComments.length > 1 && (
-        <p>View {postsComments.length} previous comments</p>
+      {postsComments.length > 1 && showAllComments === false ? (
+        <p className='view-comment-text' onClick={() => setShowAllComments(true)}>View all {postsComments.length} comments</p>
+
+      ) : (
+        <div>
+          {postsComments.length > 1 ? (
+            <p className='collapse-comments' onClick={() => setShowAllComments(false)}>Collapse all comments</p>
+
+          ) : (
+            ''
+          )}
+        </div>
 
       )}
-      <div className="one-comment">
-        <div><img className='comment-user-image' src={postsComments[postsComments.length - 1]?.user.profile_image_url} alt="" /></div>
-        <div className="full-comment">
-          <div className="user-first-last">
-            {postsComments[postsComments.length - 1]?.user.first_name} {postsComments[postsComments.length - 1]?.user.last_name}
-          </div>
-          <div className='comment-text'>{postsComments[postsComments.length - 1]?.comment_content}</div>
-        </div>
+      <div className="all-comments">
+        {showAllComments === true && postsComments.map((comment, index) => (
+                <SingleComment
+                          comment={comment}
+                          current_user={current_user}/>
+        ))}
       </div>
+          <LastComment
+                    lastComment={lastComment}
+                    current_user={current_user} />
 
     </div>
   )

--- a/react-app/src/components/Feed/LastComment/index.js
+++ b/react-app/src/components/Feed/LastComment/index.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react'
+
+const LastComment = ({ lastComment, current_user }) => {
+  const [showCommentOptions, setShowCommentOptions] = useState(false);
+
+  return (
+    <div className="one-comment"
+      onMouseEnter={() => setShowCommentOptions(true)}
+      onMouseLeave={() => setShowCommentOptions(false)}>
+      <div><img className='comment-user-image' src={lastComment?.user.profile_image_url} alt="" /></div>
+      <div className="full-comment">
+       <div className="user-first-last">
+         {lastComment?.user.first_name} {lastComment?.user.last_name}
+       </div>
+
+         <div className='comment-text'>{lastComment?.comment_content}</div>
+
+
+      </div>
+      {current_user.id === lastComment?.user.id && (
+
+       <div>
+       {showCommentOptions === false ? (
+         ''
+         ) :
+       <i className="fa-solid fa-ellipsis edit-comment-ellipsis"></i>
+       }
+      </div>
+      )}
+</div>
+  )
+}
+
+export default LastComment

--- a/react-app/src/components/Feed/SingleComment/index.js
+++ b/react-app/src/components/Feed/SingleComment/index.js
@@ -1,0 +1,29 @@
+import React, { useState } from 'react'
+
+const SingleComment = ({ comment, current_user }) => {
+  const [showCommentOptions, setShowCommentOptions] = useState(false);
+
+  return (
+    <div>
+      <div className="one-comment" onMouseEnter={() => setShowCommentOptions(true)} onMouseLeave={() => setShowCommentOptions(false)}>
+      <div><img className='comment-user-image' src={comment?.user.profile_image_url} alt="" /></div>
+      <div className="full-comment">
+        <div className="user-first-last">
+          {comment?.user.first_name} {comment?.user.last_name}
+        </div>
+          <div className='comment-text'>{comment?.comment_content}</div>
+      </div>
+      {current_user.id === comment?.user.id && (
+        <div>
+        {showCommentOptions === true && (
+          <i className="fa-solid fa-ellipsis edit-comment-ellipsis"></i>
+        )
+        }
+      </div>
+      )}
+        </div>
+    </div>
+  )
+}
+
+export default SingleComment


### PR DESCRIPTION
Issue with comment options appearing on all comments created by session-user when a single comment is hovered over. Separated last-comment from list-of-comments into independent components to solve the issue. Will return to implement a more optimal solution, but this one works just fine for now. Comment options only appear on the comment that is hovered over.